### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Imports:
     compositions,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1)
 Suggests: 
     testthat,
@@ -60,7 +60,7 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 VignetteBuilder: knitr

--- a/inst/stan/dirichregmod.stan
+++ b/inst/stan/dirichregmod.stan
@@ -4,15 +4,15 @@ data { // set up to run a single instance (1 stock) of GSI observations
   matrix[N_samples, N_bins] X; // proportions
   int N_covar; // number of covariates in design matrix X
   matrix[N_samples, N_covar] design_X;
-  int prod_idx[N_bins,N_bins-1];
+  array[N_bins,N_bins-1] int prod_idx;
   int overdisp; // whether or not to include overdispersion term
   int postpred; // whether or not to include posterior predictive samples
   real prior_sd;
 }
 transformed data {
-  int is_zero[N_samples,N_bins]; // indicator for data being 1
-  //int is_one[N_samples,N_bins]; // indicator for data being 0
-  int is_proportion[N_samples,N_bins]; // indicator which elements to estimate
+  array[N_samples,N_bins] int is_zero; // indicator for data being 1
+  //array[N_samples,N_bins] int is_one; // indicator for data being 0
+  array[N_samples,N_bins] int is_proportion; // indicator which elements to estimate
   matrix[N_samples, N_bins] logX; // log proportions
   matrix[N_samples, N_bins] logNX; // log proportions
   vector[N_samples] ESS;
@@ -134,10 +134,10 @@ model {
 generated quantities {
   real alpha_temp;
   real beta_temp;
-  vector[N_bins] log_lik[N_samples]; // log likelihood
-  vector[N_bins*postpred] ynew[N_samples*postpred]; // new data, posterior predictive distribution
-  int newy_is_zero[N_samples*postpred,N_bins*postpred];
-  int newy_is_one[N_samples*postpred,N_bins*postpred];
+  array[N_samples] vector[N_bins] log_lik; // log likelihood
+  array[N_samples*postpred] vector[N_bins*postpred] ynew; // new data, posterior predictive distribution
+  array[N_samples*postpred,N_bins*postpred] int newy_is_zero;
+  array[N_samples*postpred,N_bins*postpred] int newy_is_one;
   int newy_is_proportion;
 
   for(i in 1:N_samples) {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
